### PR TITLE
Changed the version requirement of django to be 1.8 but no greater.

### DIFF
--- a/README
+++ b/README
@@ -43,7 +43,7 @@ Everything can be installed quickly with easy_install or pip. E.g.:
 The following dependencies will be installed:
 
   * django - http://www.djangoproject.com/
-    - version 1.8 or above is required
+    - version 1.7
     - we only use the templating package, not the web serving features.
   * google-apputils - http://github.com/google/google-apputils/
   * google-api-python-client - http://github.com/google/google-api-python-client

--- a/README
+++ b/README
@@ -43,7 +43,7 @@ Everything can be installed quickly with easy_install or pip. E.g.:
 The following dependencies will be installed:
 
   * django - http://www.djangoproject.com/
-    - version 1.7
+    - version 1.8
     - we only use the templating package, not the web serving features.
   * google-apputils - http://github.com/google/google-apputils/
   * google-api-python-client - http://github.com/google/google-api-python-client

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
              'googleapis.codegen.script_stubs:RunExpandTemplates')
             ]},
     include_package_data=True,
-    install_requires=['django',
+    install_requires=['django>=1.7,<1.8',
                       'httplib2',
                       'google-apputils',
                       'python-gflags',

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
              'googleapis.codegen.script_stubs:RunExpandTemplates')
             ]},
     include_package_data=True,
-    install_requires=['django>=1.7,<1.8',
+    install_requires=['django<1.9',
                       'httplib2',
                       'google-apputils',
                       'python-gflags',


### PR DESCRIPTION
see: https//github.com/google/apis-client-generator/issues/16
and: https://github.com/google/apis-client-generator/issues/13
