### PR TITLE
Update httplib2 link

### DIFF
--- a/README
+++ b/README
@@ -48,7 +48,7 @@ The following dependencies will be installed:
   * google-apputils - http://github.com/google/google-apputils/
   * google-api-python-client - http://github.com/google/google-api-python-client
   * python-gflags - http://github.com/google/python-gflags/
-  * httplib2 - https://github.com/jcgregorio/httplib2
+  * httplib2 - http://github.com/httplib2/httplib2/
 
 
 Usage


### PR DESCRIPTION
https://github.com/jcgregorio/httplib2 is deprecated and redirects to https://github.com/httplib2/httplib2