### PR TITLE
Sometimes the canonicalName is in values but set to None.  Fix the co…

### DIFF
--- a/src/googleapis/codegen/api.py
+++ b/src/googleapis/codegen/api.py
@@ -87,7 +87,7 @@ class Api(template_objects.CodeObject):
     self._validator.ValidateApiName(name)
     if name != 'freebase':
       self._validator.ValidateApiVersion(self.values['version'])
-    canonical_name = self.values.get('canonicalName', name)
+    canonical_name = self.values.get('canonicalName') or name
     if not self.values.get('canonicalName'):
       self.values['canonicalName'] = canonical_name
     self._class_name = self.ToClassName(canonical_name, self)


### PR DESCRIPTION
…de to

accomodate that situation.

Fixes https://github.com/google/apis-client-generator/issues/26