### PR TITLE
Fixes dashes showing up in PHP method names

### DIFF
--- a/src/googleapis/codegen/php_generator.py
+++ b/src/googleapis/codegen/php_generator.py
@@ -80,7 +80,7 @@ class PHPGenerator(api_library_generator.ApiLibraryGenerator):
                                r.values['className'])
       namespaced = '_'.join((resource.GetTemplateValue('phpPropName'),
                              r.values['wireName']))
-      r.SetTemplateValue('phpPropName', namespaced)
+      r.SetTemplateValue('phpPropName', namespaced.replace('-', '_'))
       self.AnnotateResource(the_api, r)
 
   def AnnotateMethod(self, unused_api, method, resource=None):

--- a/src/googleapis/codegen/php_generator.py
+++ b/src/googleapis/codegen/php_generator.py
@@ -165,7 +165,9 @@ class PHPGenerator(api_library_generator.ApiLibraryGenerator):
     s = method['wireName']
     if resource and (s.lower() in PhpLanguageModel.PHP_KEYWORDS):
       s += resource['className']
-    return s
+    # Ensure dashes don't show up in method names
+    words = s.split('-')
+    return ''.join(words[:1] + [w.capitalize() for w in words[1:]])
 
   def _SetTypeHint(self, prop):
     """Strip primitive types since PHP doesn't support primitive type hints."""


### PR DESCRIPTION
Without this, the [Container Library](https://container.googleapis.com/$discovery/rest?version=v1) generates a class with the method name `getOpenid-configuration`, which is a syntax error.