### PR TITLE
Add @var, @param, and @return Annotations to Doc Blocks

### DIFF
--- a/src/googleapis/codegen/languages/php/1.4.0/features.json
+++ b/src/googleapis/codegen/languages/php/1.4.0/features.json
@@ -1,0 +1,14 @@
+{
+  "language": "php",
+  "description": "PHP libraries for Google APIs.",
+  "releaseVersion": "1.3.0",
+  "baseClientLibrary": "1.1.1",
+  "requires": [
+    {
+      "name": "Google API PHP Client",
+      "environments": ["*"],
+      "downloadLink": "https://github.com/google/google-api-php-client/releases",
+      "version": "${baseClientLibrary}"
+    }
+  ]
+}

--- a/src/googleapis/codegen/languages/php/1.4.0/templates/___api_className___.php.tmpl
+++ b/src/googleapis/codegen/languages/php/1.4.0/templates/___api_className___.php.tmpl
@@ -1,0 +1,70 @@
+<?php
+{% language php %}{% copyright_block %}
+
+/**
+ * Service definition for {{ api.className }} ({{ api.version }}).
+ *
+ * <p>{% filter block_comment %}
+ * {{ api.description }}
+ * {% endfilter %}</p>
+ *
+ * <p>
+ * For more information about this service, see the API
+ * <a href="{{ api.documentationLink }}" target="_blank">Documentation</a>
+ * </p>
+ *
+ * @author Google, Inc.
+ */
+class {{ api.ownerName }}_Service_{{ api.className }} extends Google_Service
+{
+{% if api.auth.oauth2.scopes %}{% filter noblanklines %}{% indent %}
+{% for authscope in api.authscopes %}
+/** {{ authscope.description }}. */
+const {{ authscope.name }} =
+    "{{ authscope.value }}";
+{% endfor %}{% endindent %}{% endfilter %}{% endif %}
+
+{% call_template _resource_var resource=api %}
+  {% if api.methods %}private $base_methods;{% endif %}
+  /**{% filter block_comment %}
+   * Constructs the internal representation of the {{ api.className }} service.
+   * {% endfilter %}
+   *
+   * @param Google_Client $client The client used to deliver requests.
+   * @param string $rootUrl The root URL used for requests to the service.
+   */
+  public function __construct(Google_Client $client, $rootUrl = null)
+  {
+{% filter noblanklines %}
+{% indent 2 %}
+parent::__construct($client);
+$this->rootUrl = $rootUrl ?: {% literal api.rootUrl %};
+$this->servicePath = {% literal api.servicePath %};
+{% if api.batchPath %}$this->batchPath = {% literal api.batchPath %};{% endif %}
+$this->version = {% literal api.version %};
+$this->serviceName = {% literal api.name %};
+{% endindent %}
+{% endfilter %}
+
+{% filter noblanklines %}
+{% call_template _resource_decl resource=api %}
+{% indent %}
+{% indent %}
+{% if api.methods %}
+$this->base_methods = new Google_Service_Resource(
+    $this,
+    $this->serviceName,
+    '{{ resource.codeName }}',
+{% indent 2 %}{% call_template _methods_decl methods=api.methods %}{% endindent %}
+);
+{% endif %}
+{% endindent %}
+{% endindent %}
+  }
+{% indent %}
+{% for m in api.methods %}
+{% call_template _method baseMethod=1 method=m %}
+{% endfor %}
+{% endindent %}
+{% endfilter %}
+}

--- a/src/googleapis/codegen/languages/php/1.4.0/templates/___api_className___/Resource/___resources_className___.php.tmpl
+++ b/src/googleapis/codegen/languages/php/1.4.0/templates/___api_className___/Resource/___resources_className___.php.tmpl
@@ -1,0 +1,15 @@
+<?php
+{% language php %}{% copyright_block %}
+
+/**
+ * The "{{ resource.wireName }}" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   ${{ api.name }}Service = new {{ api.ownerName }}_Service_{{ api.className }}(...);
+ *   ${{ resource.codeName }} = ${{ api.name }}Service->{{ resource.codeName }};
+ *  </code>
+ */
+class {{ api.ownerName }}_Service_{{ api.className }}_Resource_{{ resource.className }} extends Google_Service_Resource
+{{% indent %}{% for method in resource.methods %}
+{% call_template _method method=method %}{% endfor %}
+{% endindent %}}

--- a/src/googleapis/codegen/languages/php/1.4.0/templates/___api_className___/___models_className___.php.tmpl
+++ b/src/googleapis/codegen/languages/php/1.4.0/templates/___api_className___/___models_className___.php.tmpl
@@ -3,6 +3,13 @@
 
 class {{ api.ownerName }}_Service_{{ api.className }}_{{ model.className }} {% if model.superClass %}extends {{ api.ownerName }}_Service_{{ api.className }}_{{ model.superClass }}{% else %}{% if model.dataType == "array" %}extends Google_Collection{% else %}extends Google_Model{% endif %}{% endif %}
 {{% if model.properties %}
+{% for property in model.properties %}
+{% if property.enum %}
+{% for enum in property.enum %}
+  const {{ property.memberName|upper }}_{{ enum.constName|upper }} = "{{ enum.value }}";
+{% endfor %}
+{% endif %}
+{% endfor %}
 {% filter noblanklines %}
 {% if not model.is_variant_base and model.collectionKey %}
   protected $collection_key = '{{ model.collectionKey }}';

--- a/src/googleapis/codegen/languages/php/1.4.0/templates/___api_className___/___models_className___.php.tmpl
+++ b/src/googleapis/codegen/languages/php/1.4.0/templates/___api_className___/___models_className___.php.tmpl
@@ -38,11 +38,9 @@ class {{ api.ownerName }}_Service_{{ api.className }}_{{ model.className }} {% i
  {% endif %}
 {% endfilter %}{% for property in model.properties %}
 {% filter noblanklines %}
-{% if property.typeHint %}
   /**
-   * @param {{ property.typeHint }}
+   * @param {% if property.typeHint %}{{ property.typeHint }}{% else %}{{ property.varAnnotation }}{% endif %}
    */
-{% endif %}
   {% if property.type == "array" or property.dataType == "map" or not property.typeHint %}
   public function {{ property.setterName }}(${{ property.memberName }})
   {% else %}
@@ -52,11 +50,9 @@ class {{ api.ownerName }}_Service_{{ api.className }}_{{ model.className }} {% i
     $this->{{ property.memberName }} = ${{ property.memberName }};
   }
 
-{% if property.typeHint %}
   /**
-   * @return {{ property.typeHint }}
+   * @return {% if property.typeHint %}{{ property.typeHint }}{% else %}{{ property.varAnnotation }}{% endif %}
    */
-{% endif %}
   public function {{ property.getterName }}()
   {
     return $this->{{ property.memberName }};

--- a/src/googleapis/codegen/languages/php/1.4.0/templates/___api_className___/___models_className___.php.tmpl
+++ b/src/googleapis/codegen/languages/php/1.4.0/templates/___api_className___/___models_className___.php.tmpl
@@ -3,6 +3,7 @@
 
 class {{ api.ownerName }}_Service_{{ api.className }}_{{ model.className }} {% if model.superClass %}extends {{ api.ownerName }}_Service_{{ api.className }}_{{ model.superClass }}{% else %}{% if model.dataType == "array" %}extends Google_Collection{% else %}extends Google_Model{% endif %}{% endif %}
 {{% if model.properties %}
+{% filter noblanklines %}
 {% for property in model.properties %}
 {% if property.enum %}
 {% for enum in property.enum %}
@@ -10,7 +11,6 @@ class {{ api.ownerName }}_Service_{{ api.className }}_{{ model.className }} {% i
 {% endfor %}
 {% endif %}
 {% endfor %}
-{% filter noblanklines %}
 {% if not model.is_variant_base and model.collectionKey %}
   protected $collection_key = '{{ model.collectionKey }}';
 {% endif %}{% if model.has_gapi %}
@@ -48,10 +48,12 @@ class {{ api.ownerName }}_Service_{{ api.className }}_{{ model.className }} {% i
   /**
    * @param {% if property.typeHint %}{{ property.typeHint }}{% else %}{{ property.varAnnotation }}{% endif %}
    */
-  {% if property.type == "array" or property.dataType == "map" or not property.typeHint %}
-  public function {{ property.setterName }}(${{ property.memberName }})
-  {% else %}
+  {% if property.type == "array" or property.dataType == "map" %}
+  public function {{ property.setterName }}(array ${{ property.memberName }})
+  {% elif property.typeHint %}
   public function {{ property.setterName }}({{ property.typeHint }} ${{ property.memberName }})
+  {% else %}
+  public function {{ property.setterName }}(${{ property.memberName }})
   {% endif %}
   {
     $this->{{ property.memberName }} = ${{ property.memberName }};

--- a/src/googleapis/codegen/languages/php/1.4.0/templates/___api_className___/___models_className___.php.tmpl
+++ b/src/googleapis/codegen/languages/php/1.4.0/templates/___api_className___/___models_className___.php.tmpl
@@ -30,7 +30,7 @@ class {{ api.ownerName }}_Service_{{ api.className }}_{{ model.className }} {% i
   {% endif %}
  {% else %}
   /**
-   * @var {{ property.varAnnotation }}
+   * @var {{ property.varAnnotation }}{% if property.type == "array" or property.dataType == "map" %}[]{% endif %}
    */
   public ${{ property.memberName }};
  {% endif %}
@@ -46,7 +46,7 @@ class {{ api.ownerName }}_Service_{{ api.className }}_{{ model.className }} {% i
 {% endfilter %}{% for property in model.properties %}
 {% filter noblanklines %}
   /**
-   * @param {% if property.typeHint %}{{ property.typeHint }}{% else %}{{ property.varAnnotation }}{% endif %}
+   * @param {% if property.typeHint %}{{ property.typeHint }}{% else %}{{ property.varAnnotation }}{% endif %}{% if property.type == "array" or property.dataType == "map" %}[]{% endif %}
    */
   {% if property.type == "array" or property.dataType == "map" %}
   public function {{ property.setterName }}(array ${{ property.memberName }})
@@ -60,7 +60,7 @@ class {{ api.ownerName }}_Service_{{ api.className }}_{{ model.className }} {% i
   }
 
   /**
-   * @return {% if property.typeHint %}{{ property.typeHint }}{% else %}{{ property.varAnnotation }}{% endif %}
+   * @return {% if property.typeHint %}{{ property.typeHint }}{% else %}{{ property.varAnnotation }}{% endif %}{% if property.type == "array" or property.dataType == "map" %}[]{% endif %}
    */
   public function {{ property.getterName }}()
   {

--- a/src/googleapis/codegen/languages/php/1.4.0/templates/___api_className___/___models_className___.php.tmpl
+++ b/src/googleapis/codegen/languages/php/1.4.0/templates/___api_className___/___models_className___.php.tmpl
@@ -46,7 +46,7 @@ class {{ api.ownerName }}_Service_{{ api.className }}_{{ model.className }} {% i
 {% endfilter %}{% for property in model.properties %}
 {% filter noblanklines %}
   /**
-   * @param {% if property.typeHint %}{{ property.typeHint }}{% else %}{{ property.varAnnotation }}{% endif %}{% if property.type == "array" or property.dataType == "map" %}[]{% endif %}
+   * @param {% if property.typeHint %}{{ property.typeHint }}{% else %}{{ property.varAnnotation }}{% endif %}{% if property.type == "array" or property.dataType == "map" %}[]{% endif %} ${{ property.memberName }}
    */
   {% if property.type == "array" or property.dataType == "map" %}
   public function {{ property.setterName }}(array ${{ property.memberName }})

--- a/src/googleapis/codegen/languages/php/1.4.0/templates/___api_className___/___models_className___.php.tmpl
+++ b/src/googleapis/codegen/languages/php/1.4.0/templates/___api_className___/___models_className___.php.tmpl
@@ -1,0 +1,65 @@
+<?php
+{% language php %}{% copyright_block %}
+
+class {{ api.ownerName }}_Service_{{ api.className }}_{{ model.className }} {% if model.superClass %}extends {{ api.ownerName }}_Service_{{ api.className }}_{{ model.superClass }}{% else %}{% if model.dataType == "array" %}extends Google_Collection{% else %}extends Google_Model{% endif %}{% endif %}
+{{% if model.properties %}
+{% filter noblanklines %}
+{% if not model.is_variant_base and model.collectionKey %}
+  protected $collection_key = '{{ model.collectionKey }}';
+{% endif %}{% if model.has_gapi %}
+  protected $internal_gapi_mappings = array(
+    {% for property in model.properties %}
+      {% if not property.member_name_is_json_name %}
+        "{{ property.memberName }}" => "{{ property.wireName }}",
+      {% endif %}
+    {% endfor %}
+  );
+{% endif %}{% for property in model.properties %}
+ {% if property.typeHint %}
+  {% if property.memberName|add:"Type" not in model.propNames %}
+  protected ${{ property.memberName }}Type = '{{ property.typeHint|cut:" " }}';
+  {% endif %}{% if property.memberName|add:"DataType" not in model.propNames %}
+  protected ${{ property.memberName }}DataType = '{{ property.dataType }}';
+  {% endif %}
+ {% else %}
+  /**
+   * @var {{ property.varAnnotation }}
+   */
+  public ${{ property.memberName }};
+ {% endif %}
+{% endfor %}
+{% endfilter %}
+{% filter noblanklines %}
+ {% if model.discriminantValue %}
+  protected function gapiInit()
+  {
+    $this->type = {% literal model.discriminantValue %};
+  }
+ {% endif %}
+{% endfilter %}{% for property in model.properties %}
+{% filter noblanklines %}
+{% if property.typeHint %}
+  /**
+   * @param {{ property.typeHint }}
+   */
+{% endif %}
+  {% if property.type == "array" or property.dataType == "map" or not property.typeHint %}
+  public function {{ property.setterName }}(${{ property.memberName }})
+  {% else %}
+  public function {{ property.setterName }}({{ property.typeHint }} ${{ property.memberName }})
+  {% endif %}
+  {
+    $this->{{ property.memberName }} = ${{ property.memberName }};
+  }
+
+{% if property.typeHint %}
+  /**
+   * @return {{ property.typeHint }}
+   */
+{% endif %}
+  public function {{ property.getterName }}()
+  {
+    return $this->{{ property.memberName }};
+  }
+{% endfilter %}{% endfor %}{% endif %}
+}

--- a/src/googleapis/codegen/languages/php/1.4.0/templates/_func_params.tmpl
+++ b/src/googleapis/codegen/languages/php/1.4.0/templates/_func_params.tmpl
@@ -1,0 +1,11 @@
+{% parameter_list %}
+  {% for p in method.requiredParameters %}
+    {% parameter %}{{ p.typeHint }} ${{p.memberName}}{% end_parameter %}
+  {% endfor %}
+  {% if method.requestType %}
+    {% parameter %}
+      {{ api.ownerName }}_Service_{{ api.className }}_{{ method.requestType.className }} $postBody
+    {% end_parameter %}
+  {% endif %}
+  {% parameter %}$optParams = array(){% end_parameter %}
+{% end_parameter_list %}

--- a/src/googleapis/codegen/languages/php/1.4.0/templates/_method.tmpl
+++ b/src/googleapis/codegen/languages/php/1.4.0/templates/_method.tmpl
@@ -1,0 +1,41 @@
+/**{% filter block_comment %}
+ * {{ method.description }} ({% if resource %}{{ resource.wireName }}.{% endif %}{{ method.name }})
+ * {% endfilter %}
+ *
+{% filter noblanklines %}
+{% for param in method.required_parameters %}{% filter block_comment %}
+ * @param {{ param.codeType }}{% if param.repeated %}|array{% endif %} ${{ param.memberName }}
+ * {{ param.description }}{% endfilter %}{% endfor %}
+{% if method.requestType %}
+ * @param {{ api.ownerName }}_Service_{{ api.className }}_{{ method.requestType.className }} $postBody
+{% endif %}
+ * @param array $optParams Optional parameters.
+{% if method.optional_parameters %}
+ *{% for param in method.optional_parameters %}{% filter block_comment %}
+ * @opt_param {{ param.codeType }} {{ param.wireName }}
+ * {{ param.description }}{% endfilter %}{% endfor %}
+{% endif %}
+{% if method.response %}
+ * @return {{ api.ownerName }}_Service_{{ api.className }}_{{ method.responseType.className }}
+{% endif %}
+ */
+{% endfilter %}
+public function {{ method.name }}({% call_template _func_params method=method %})
+{
+{% filter noblanklines %}
+  $params = array({% parameter_list %}
+    {% for p in method.requiredParameters %}
+      {% parameter %}'{{ p.wireName }}' => ${{ p.memberName }}{% end_parameter %}
+    {% endfor %}
+    {% if method.requestType %}
+      {% parameter %}'postBody' => $postBody{% end_parameter %}
+    {% endif %}
+  {% end_parameter_list %});
+  $params = array_merge($params, $optParams);
+{% if method.response %}
+  return $this->{% if baseMethod == 1 %}base_methods->{% endif %}call('{{ method.wireName }}', array($params), "{{ api.ownerName }}_Service_{{ api.className }}_{{ method.responseType.className }}");
+{% else %}
+  return $this->{% if baseMethod == 1 %}base_methods->{% endif %}call('{{ method.wireName }}', array($params));
+{% endif %}
+{% endfilter %}
+}

--- a/src/googleapis/codegen/languages/php/1.4.0/templates/_methods_decl.tmpl
+++ b/src/googleapis/codegen/languages/php/1.4.0/templates/_methods_decl.tmpl
@@ -1,0 +1,16 @@
+array(
+  'methods' => array(
+    {% for method in methods %}{% literal method.wireName %} => array(
+      'path' => {% literal method.path %},
+      'httpMethod' => {% literal method.httpMethod %},
+      'parameters' => array({% for p in method.parameters %}
+        {% literal p.wireName %} => array(
+          'location' => {% literal p.location %},
+          'type' => {% literal p.type %},
+          {% if p.repeated %}'repeated' => true,{% endif %}
+          {% if p.required %}'required' => true,{% endif %}
+        ),
+      {% endfor %}),
+    ),{% endfor %}
+  )
+)

--- a/src/googleapis/codegen/languages/php/1.4.0/templates/_resource_decl.tmpl
+++ b/src/googleapis/codegen/languages/php/1.4.0/templates/_resource_decl.tmpl
@@ -1,0 +1,14 @@
+{% filter noblanklines %}
+{% if resource.json %}
+    $this->{{ resource.phpPropName }} = new {{ api.ownerName }}_Service_{{ api.className }}_Resource_{{ resource.className }}(
+        $this,
+        $this->serviceName,
+        '{{ resource.codeName }}',
+{% indent 4 %}{% call_template _methods_decl methods=resource.methods %}{% endindent %}
+    );
+{% endif %}
+
+{% for r in resource.resources %}
+{% call_template _resource_decl resource=r %}
+{% endfor %}
+{% endfilter %}

--- a/src/googleapis/codegen/languages/php/1.4.0/templates/_resource_var.tmpl
+++ b/src/googleapis/codegen/languages/php/1.4.0/templates/_resource_var.tmpl
@@ -1,0 +1,10 @@
+{% filter noblanklines %}
+
+{% if resource.json and resource.phpPropName %}
+  public ${{ resource.phpPropName }};
+{% endif %}
+
+{% for r in resource.resources %}
+{% call_template _resource_var resource=r %}
+{% endfor %}
+{% endfilter %}

--- a/src/googleapis/codegen/languages/php/1.4.0/templates/_resource_var.tmpl
+++ b/src/googleapis/codegen/languages/php/1.4.0/templates/_resource_var.tmpl
@@ -1,6 +1,9 @@
 {% filter noblanklines %}
 
 {% if resource.json and resource.phpPropName %}
+  /**
+   * @var {{ api.ownerName }}_Service_{{ api.className }}_Resource_{{ resource.className }}
+   */
   public ${{ resource.phpPropName }};
 {% endif %}
 

--- a/src/googleapis/codegen/php_generator.py
+++ b/src/googleapis/codegen/php_generator.py
@@ -31,6 +31,7 @@ __author__ = 'chirags@google.com (Chirag Shah)'
 import collections
 import json
 import operator
+import re
 
 from googleapis.codegen import api
 from googleapis.codegen import api_library_generator
@@ -39,6 +40,7 @@ from googleapis.codegen import language_model
 from googleapis.codegen import utilities
 from googleapis.codegen.schema import Schema
 
+CONST_NAME_SUB = re.compile('[^a-zA-Z0-9_]+')
 
 class PHPGenerator(api_library_generator.ApiLibraryGenerator):
   """The PHP code generator."""
@@ -137,6 +139,7 @@ class PHPGenerator(api_library_generator.ApiLibraryGenerator):
     schema.SetTemplateValue('propNames', prop_names)
 
     self._SetTypeHint(prop)
+    self._SetEnum(prop)
 
   def _GenerateLibrarySource(self, the_api, source_package_writer):
     """Default operations to generate the package.
@@ -186,6 +189,23 @@ class PHPGenerator(api_library_generator.ApiLibraryGenerator):
       prop.values['typeHint'] = ('%s_Service_%s_%s' %
                                  (self._api.values['owner'].title(),
                                   self._api.values['className'], code_type))
+
+  def _SetEnum(self, prop):
+    enum = prop.values.get('enum')
+    if enum is None:
+      return
+
+    newEnum = []
+    enumDescriptions = prop.values.get('enumDescriptions') or []
+    for i, value in enumerate(enum):
+        newEnum.append({
+            'value': value,
+            'constName': CONST_NAME_SUB.sub('_', value),
+            'description': enumDescriptions[i] if i in enumDescriptions else None,
+        })
+
+    prop.values['oldEnum'] = enum
+    prop.values['enum'] = newEnum
 
 
 class PhpLanguageModel(language_model.LanguageModel):

--- a/src/googleapis/codegen/php_generator.py
+++ b/src/googleapis/codegen/php_generator.py
@@ -176,6 +176,7 @@ class PHPGenerator(api_library_generator.ApiLibraryGenerator):
     """Strip primitive types since PHP doesn't support primitive type hints."""
     code_type = prop.code_type
     if code_type and code_type.lower() in PhpLanguageModel.PHP_TYPES:
+      prop.values['varAnnotation'] = code_type.lower()
       prop.values['typeHint'] = ''
       prop.values['typeHintOld'] = ''
     else:


### PR DESCRIPTION
There are a couple things here in a new php *version*. We had a use case for these on a still private Google API, so I thought I would send the changes back.

- All public variables now have a docblock with `@var {primitiveType}` annotations
- All setters have a docblock (previously only non-primitive type setters did) with `@param` annotations
- All getters have a docblock with `@return` annotations (previously only non-primitive type getters did)
- Adds possible enum values as `{propertyName}_{enumValue}` constants on model classes. Not 100% on this one, but we had a use case for it and it matches, somewhat, what the adwords PHP SDK does. AdWords sets those constants for enum-like values as constants on a separate object.
- Puts an `array` typehint on `array` and `map` type setters
- All `@var`, `@return`, and `@param` annotations include brackets (`[]`) for array types

Most of this is geared towards playing a little nicer with IDE and reflection libraries and removing some guess work (or, more likely, removing some trips to the API documentation).

I can sort of navigate the `php_generator_test.py` stuff, but I'm unsure how to work with the end to end tests in `golden_tests.py`.